### PR TITLE
Fix pre width

### DIFF
--- a/public/pastisserie.css
+++ b/public/pastisserie.css
@@ -91,6 +91,9 @@ input[type="submit"]{
 	);
 
 }
+pre{
+	width: fit-content;
+}
 
 @media (max-width: 600px) {
   	body{


### PR DESCRIPTION
When scrolling across a long text paragraph, text became invisible. This fix sets correctly pre width.

Here is an example: https://paste.osau.re/xEU?ln=true#eyJhbGciOiJBMTI4Q0JDIiwiZXh0Ijp0cnVlLCJrIjoidnYxSUg4T2owMmdocDZBWkl6c1FNQSIsImtleV9vcHMiOlsiZW5jcnlwdCIsImRlY3J5cHQiXSwia3R5Ijoib2N0In0=